### PR TITLE
Add a SelectAndDelete Token deletion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ All tokens will turn into the partial completion text they replaced
 
 Tokens will be replaced with the toString value of the objects they represent when they are deleted
 
+#### TokenCompleteTextView.TokenDeleteStyle.SelectThenDelete
+
+This mode will first select the token and when pressing the 'delete' key again it'll delete the selected token
+
 Restoring the view state
 ========================
 

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -61,7 +61,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         _Parent, //...do the parent behavior, not recommended
         Clear, //...clear the underlying text
         PartialCompletion, //...return the original text used for completion
-        ToString //...replace the token with toString of the token object
+        ToString, //...replace the token with toString of the token object
+        SelectThenDelete //...first backspace selects the token and another backspace deletes it
     }
 
     //When the user clicks on a token...
@@ -835,6 +836,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         //if the token gets deleted, this text will get put in the field instead
         switch (deletionStyle) {
             case Clear:
+            case SelectThenDelete:
                 return "";
             case PartialCompletion:
                 return currentCompletionText();
@@ -1517,7 +1519,23 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             int endTokenSelection = text.getSpanEnd(span);
 
             // moving on, no need to check this token
-            if (isTokenRemovable(span.token)) continue;
+            if (isTokenRemovable(span.token)) {
+                if (deletionStyle == TokenDeleteStyle.SelectThenDelete) {
+                    if (span.view.isSelected()) {
+                        // If a token is already selected then we can just delete it
+                        return true;
+                    }
+                    // If we're not selecting multiple characters and we want to remove the current token
+                    if (startSelection == endSelection && endTokenSelection + 1 == endSelection && !span.view.isSelected()) {
+                        // Just select it and don't delete it, the next backspace will delete it
+                        clearSelections();
+                        span.view.setSelected(true);
+                        invalidate();
+                        return false;
+                    }
+                }
+                continue;
+            }
 
             if (startSelection == endSelection) {
                 // Delete single
@@ -1552,10 +1570,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             //Shouldn't be able to delete prefix, so don't do anything
             if (getSelectionStart() <= prefix.length()) {
                 beforeLength = 0;
-                return deleteSelectedObject(false) || super.deleteSurroundingText(beforeLength, afterLength);
             }
-
-            return super.deleteSurroundingText(beforeLength, afterLength);
+            return deleteSelectedObject(false) || super.deleteSurroundingText(beforeLength, afterLength);
         }
     }
 }


### PR DESCRIPTION
**This is the same PR as https://github.com/splitwise/TokenAutoComplete/pull/243 but I'd like to get this merged/released quicker so that's why I'm making this PR as well**

----

What this does is: When you press the delete key it'll first select the
token on the left to the cursor and then pressing the delete key again
will actually delete the token.

Del -> Select the token -> Del -> Removes the token

Demo using the `SelectAndDelete` mode |
--- |
<img src="https://cloud.githubusercontent.com/assets/1626673/17398459/3f2dd124-5a3d-11e6-8692-a16ac60f12c4.gif" width="320" /> |

